### PR TITLE
Add automatic PyPI release workflow

### DIFF
--- a/.github/PYPI_RELEASE_SETUP.md
+++ b/.github/PYPI_RELEASE_SETUP.md
@@ -1,0 +1,64 @@
+# PyPI Automatic Release Setup
+
+This repository now includes an automated workflow to publish releases to PyPI.
+
+## How It Works
+
+The workflow (`.github/workflows/pypi-publish.yml`) automatically publishes the package to PyPI when a new GitHub release is created.
+
+## Setup Instructions
+
+### 1. Create a PyPI API Token
+
+1. Go to [PyPI Account Settings](https://pypi.org/manage/account/)
+2. Scroll down to "API tokens" section
+3. Click "Add API token"
+4. Set the token name (e.g., "redback_surrogates GitHub Actions")
+5. Set the scope to "Project: redback_surrogates" (or "Entire account" if preferred)
+6. Copy the generated token (starts with `pypi-`)
+
+### 2. Add the Token to GitHub Secrets
+
+1. Go to your GitHub repository settings
+2. Navigate to "Secrets and variables" → "Actions"
+3. Click "New repository secret"
+4. Name: `PYPI_API_TOKEN`
+5. Value: Paste the PyPI token you copied
+6. Click "Add secret"
+
+### 3. Creating a Release
+
+To trigger an automatic PyPI upload:
+
+1. Update the version in `setup.py`
+2. Commit and push your changes
+3. Create a new release on GitHub:
+   - Go to "Releases" → "Create a new release"
+   - Create a new tag (e.g., `v0.2.6`)
+   - Write release notes
+   - Click "Publish release"
+
+The workflow will automatically:
+- Build the package
+- Check the package for errors
+- Upload it to PyPI
+
+## Alternative: Trusted Publisher (Recommended)
+
+Instead of using API tokens, PyPI now supports "Trusted Publishers" which is more secure:
+
+1. Go to your PyPI project page
+2. Navigate to "Publishing"
+3. Add GitHub as a trusted publisher:
+   - Owner: `nikhil-sarin`
+   - Repository: `redback_surrogates`
+   - Workflow: `pypi-publish.yml`
+   - Environment: (leave blank)
+
+Then update the workflow to remove the `password` parameter (it will authenticate automatically).
+
+## Troubleshooting
+
+- Ensure the version in `setup.py` is incremented before each release
+- Check the Actions tab on GitHub to see workflow execution logs
+- Verify the `PYPI_API_TOKEN` secret is correctly set

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,40 @@
+# This workflow will upload a Python Package to PyPI when a release is published
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+name: Upload Python Package to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build twine
+
+    - name: Build package
+      run: python -m build
+
+    - name: Check package
+      run: twine check dist/*
+
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This commit adds a GitHub Actions workflow that automatically publishes the package to PyPI when a new release is created on GitHub.

Changes:
- Add .github/workflows/pypi-publish.yml: Workflow that triggers on release publication, builds the package, and uploads it to PyPI
- Add .github/PYPI_RELEASE_SETUP.md: Documentation on how to set up the PyPI API token and use the automatic release workflow

The workflow uses the modern 'build' package and includes package validation before publishing. Setup instructions include both API token and trusted publisher methods.